### PR TITLE
Fix first page bottom padding

### DIFF
--- a/fim-uhk-thesis.cls
+++ b/fim-uhk-thesis.cls
@@ -637,6 +637,7 @@
   
 \vfill
 \noindent\mktxtcn{12}{Hradec Králové \hfill \@year\hspace{5.0pt}~}
+\vfill
 
 \iftwoside
   \newgeometry{left=3.46cm, text={15.2cm,23.0cm}, top=2.96cm}


### PR DESCRIPTION
I'm not sure whether this is the correct approach, but I was struggling with the bottom padding on the first page and this change fixed the issue for me.

**Behaviour before the change:**
There was no bottom padding on the first page.

**Expected behaviour:**
There is a bottom padding on the first page like in the official UHK template.

**Additional notes:**
I used Overleaf to compile the template.

**Showcase:**
Left PDF is before the change, right PDF is after the change.

![CleanShot 2023-11-27 at 22 07 43](https://github.com/spisovatelprogramu/uhk-thesis-latex-template/assets/9418772/d9d18129-eb5e-4f16-af60-5484925a2772)
